### PR TITLE
[BREAKING] Added errors, tests, functions & fixed documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,39 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +45,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "cpufeatures"
@@ -30,9 +136,79 @@ dependencies = [
 name = "create3"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "hex",
  "rand",
  "sha3",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -53,6 +229,33 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -77,10 +280,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "keccak"
@@ -93,15 +343,109 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memchr"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -134,6 +478,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "rustix"
+version = "0.38.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,10 +602,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
@@ -156,7 +641,178 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,10 @@ keywords = ["create3", "evm", "ethereum"]
 hex = "0.4.3"
 rand = "0.8.5"
 sha3 = "0.10.6"
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "async_benchmark"
+harness = false

--- a/benches/async_benchmark.rs
+++ b/benches/async_benchmark.rs
@@ -1,0 +1,30 @@
+use std::time::Duration;
+
+use create3::{generate_salt, generate_salt_async};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+
+fn generate_salt_benchmark(c: &mut Criterion) {
+    let prefix = black_box("0000");
+    let deployer = black_box(hex::decode("0fC5025C764cE34df352757e82f7B5c4Df39A836").unwrap());
+
+    c.bench_function("single-threaded generate salt", |b| {
+        b.iter(|| generate_salt(&deployer, prefix))
+    });
+}
+
+fn generate_salt_async_benchmark(c: &mut Criterion) {
+    let prefix = black_box("0000");
+    let deployer = black_box(hex::decode("0fC5025C764cE34df352757e82f7B5c4Df39A836").unwrap());
+
+    c.bench_function("multi-threaded generate salt", |b| {
+        b.iter(|| generate_salt_async(&deployer, prefix))
+    });
+}
+
+criterion_group!(
+    name = benches;   
+    config = Criterion::default().measurement_time(Duration::from_secs(15));
+    targets = generate_salt_benchmark, generate_salt_async_benchmark
+);
+criterion_main!(benches);

--- a/benches/async_benchmark.rs
+++ b/benches/async_benchmark.rs
@@ -18,7 +18,7 @@ fn generate_salt_async_benchmark(c: &mut Criterion) {
     let deployer = black_box(hex::decode("0fC5025C764cE34df352757e82f7B5c4Df39A836").unwrap());
 
     c.bench_function("multi-threaded generate salt", |b| {
-        b.iter(|| generate_salt_async(&deployer, prefix))
+        b.iter(|| generate_salt_async(&deployer, prefix, 6))
     });
 }
 

--- a/benches/async_benchmark.rs
+++ b/benches/async_benchmark.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
-use create3::{generate_salt, generate_salt_async};
+use create3::{
+    generate_salt, generate_salt_multithread, generate_salt_prefix,
+    generate_salt_prefix_multithread,
+};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-
 
 fn generate_salt_benchmark(c: &mut Criterion) {
     let prefix = black_box("0000");
@@ -13,18 +15,38 @@ fn generate_salt_benchmark(c: &mut Criterion) {
     });
 }
 
-fn generate_salt_async_benchmark(c: &mut Criterion) {
+fn generate_salt_multithread_benchmark(c: &mut Criterion) {
     let prefix = black_box("0000");
     let deployer = black_box(hex::decode("0fC5025C764cE34df352757e82f7B5c4Df39A836").unwrap());
 
     c.bench_function("multi-threaded generate salt", |b| {
-        b.iter(|| generate_salt_async(&deployer, prefix, 6))
+        b.iter(|| generate_salt_multithread(&deployer, prefix, 6))
+    });
+}
+
+fn generate_salt_prefix_benchmark(c: &mut Criterion) {
+    let prefix = black_box("0000");
+    let salt_prefix = black_box("my_prefix_");
+    let deployer = black_box(hex::decode("0fC5025C764cE34df352757e82f7B5c4Df39A836").unwrap());
+
+    c.bench_function("single-threaded generate salt", |b| {
+        b.iter(|| generate_salt_prefix(&deployer, salt_prefix, prefix))
+    });
+}
+
+fn generate_salt_prefix_multithread_benchmark(c: &mut Criterion) {
+    let prefix = black_box("0000");
+    let salt_prefix = black_box("my_prefix_");
+    let deployer = black_box(hex::decode("0fC5025C764cE34df352757e82f7B5c4Df39A836").unwrap());
+
+    c.bench_function("multi-threaded generate salt", |b| {
+        b.iter(|| generate_salt_prefix_multithread(&deployer, salt_prefix, prefix, 6))
     });
 }
 
 criterion_group!(
-    name = benches;   
+    name = generate_salt_benches;
     config = Criterion::default().measurement_time(Duration::from_secs(15));
-    targets = generate_salt_benchmark, generate_salt_async_benchmark
+    targets = generate_salt_benchmark, generate_salt_multithread_benchmark, generate_salt_prefix_benchmark, generate_salt_prefix_multithread_benchmark
 );
-criterion_main!(benches);
+criterion_main!(generate_salt_benches);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,27 @@
+use std::{error::Error, fmt::Display};
+
+/// Errors for generating a CREATE3 salt.
+#[derive(Debug, PartialEq)]
+pub enum Create3GenerateSaltError {
+    /// Occurs if the prefix is too long. The prefix must be less than or equal to 20 bytes.
+    PrefixTooLong,
+    // Occurs if the prefix is not a hex encoded string. The prefix must be in hexadecimal format.
+    PrefixNotHexEncoded,
+}
+
+impl Error for Create3GenerateSaltError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+impl Display for Create3GenerateSaltError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Create3GenerateSaltError::PrefixTooLong => 
+                "Create3GenerateSaltError::PrefixTooLong: the prefix is too long. The prefix must be less than or equal to 20 bytes.",
+            Create3GenerateSaltError::PrefixNotHexEncoded => 
+                "Create3GenerateSaltError::PrefixNotHexEncoded: the prefix is not a hex encoded string. The prefix must be in hexadecimal format.",
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,7 @@ use rand::{distributions::Alphanumeric, Rng};
 use sha3::{Digest, Keccak256};
 
 // TODO: create fn that accepts salt as &[u8; 32] instead of just &[u8]
-// TODO: rename functions in major release to make sense with previously mentioned fn
-// TODO: should panic/return a Result object if prefix/suffix has incorrect characters
+// TODO: rename functions in major release to make sense with previously mentioned fn// TODO: should panic/return a Result object if prefix/suffix has incorrect characters
 // TODO: add regex fn for salt generation
 // TODO: convert panics into Results
 // TODO: rename the salt_suffix argument to salt_prefix
@@ -29,10 +28,25 @@ pub fn calc_addr(deployer: &[u8], salt: &[u8]) -> [u8; 20] {
     // [contract creation prefix] + [create3 deployer] + [salt] + [keccak256(childBytecode)]
     let salt_hash = Keccak256::digest(salt);
     // println!("Salt hash: 0x{}", hex::encode(&salt_hash));
+
+    calc_addr_with_bytes(deployer, &salt_hash.as_slice()[0.. 32].try_into().unwrap())
+}
+
+/// Calculates the address of a contract based on the given deployer and salt.
+/// 
+/// # Arguments
+///
+/// * `deployer` - A byte slice representing the create3 deployer address.
+/// * `salt` - Bytes in u8 array format that is directly used as the salt input.
+///
+/// # Returns
+///
+/// A 20-byte array representing the address of the contract.
+pub fn calc_addr_with_bytes(deployer: &[u8], salt: &[u8; 32]) -> [u8; 20] {
     let mut bytes: Vec<u8> = Vec::new();
     bytes.push(0xff);
     bytes.extend_from_slice(deployer);
-    bytes.extend_from_slice(&salt_hash);
+    bytes.extend_from_slice(salt);
     bytes.extend_from_slice(&KECCAK256_PROXY_CHILD_BYTECODE);
     let hash = Keccak256::digest(&bytes);
     let mut proxy_bytes = [0u8; 20];
@@ -140,10 +154,10 @@ pub fn generate_salt_suffix(deployer: &[u8], salt_suffix: &str, prefix: &str) ->
 #[cfg(test)]
 mod tests {
     use sha3::{Digest, Keccak256};
-    use crate::{calc_addr, generate_salt, generate_salt_suffix, KECCAK256_PROXY_CHILD_BYTECODE};
+    use crate::{calc_addr, generate_salt, generate_salt_suffix, KECCAK256_PROXY_CHILD_BYTECODE, calc_addr_with_bytes};
 
     #[test]
-    fn should_calculate_correctly_with_given_salt() {
+    fn should_calculate_correctly_with_given_salt_string() {
         let deployer: &Vec<u8> = &hex::decode("0fC5025C764cE34df352757e82f7B5c4Df39A836").unwrap();
 
         // Answers were generated with the Solady CREATE3 library
@@ -164,6 +178,27 @@ mod tests {
     }
 
     #[test]
+    fn should_calculate_correctly_with_given_salt() {
+        let deployer = &hex::decode("d8b934580fcE35a11B58C6D73aDeE468a2833fa8").unwrap();
+
+        // Answers were generated with the Solady CREATE3 library
+        // https://github.com/Vectorized/solady/blob/main/src/utils/CREATE3.sol
+        let correct_answers: Vec<(&str, &str)> = vec![
+            ("3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb", "442188F25da4ac213D55aE81F1BFB421a4eb4562"),
+            ("b5553de315e0edf504d9150af82dafa5c4667fa618ed0a6f19c69b41166c5510", "551b9d8A7106Fdf98e68c4bf12Da1f23ad70C815"),
+            ("0b42b6393c1f53060fe3ddbfcd7aadcca894465a5a438f69c87d790b2299b9b2", "43d8e8C69fd771f7D3F4e25697Dadd3cC11D1cDB"),
+            ("ead17456afde832907c72ba39033455130a8f4d540a869ba31312c2746bf9c4b", "AB3D55404C5C21D18403A71aF5f6887BD0EC8d56")
+        ];
+
+        for (salt, answer) in correct_answers.iter() {
+            let salt: [u8; 32] = hex::decode(*salt).unwrap()[0.. 32].try_into().unwrap();
+            let addr: [u8; 20] = calc_addr_with_bytes(deployer, &salt);
+            let addr_str = hex::encode(addr);
+            assert_eq!(addr_str, answer.to_lowercase());
+        }
+    }
+
+    #[test]
     fn should_generate_with_prefix() {
         let deployer: &Vec<u8> = &hex::decode("5e17b14ADd6c386305A32928F985b29bbA34Eff5").unwrap();
         let runs = vec!["0", "00", "000", "abc", "123", "789"];
@@ -171,30 +206,13 @@ mod tests {
         for run in runs.iter() {
             let salt = generate_salt(deployer, run);
             
-            // NOTE:    would rather the library expose a function. Waiting until major release to do so
-            //          let addr: [u8; 20] = calc_addr_with_bytes(deployer, &salt);
-            let mut bytes: Vec<u8> = Vec::new();
-            bytes.push(0xff);
-            bytes.extend_from_slice(deployer);
-            bytes.extend_from_slice(&salt);
-            bytes.extend_from_slice(&KECCAK256_PROXY_CHILD_BYTECODE);
-            let hash = Keccak256::digest(&bytes);
-            let mut proxy_bytes = [0u8; 20];
-            proxy_bytes.copy_from_slice(&hash[12..]);
-        
-            // Use proxy address to compute the final contract address.
-            // keccak256(rlp(proxy_bytes ++ 0x01)) More here -> https://ethereum.stackexchange.com/a/761/66849
-            let mut bytes2: Vec<u8> = Vec::new();
-            bytes2.extend_from_slice(&[0xd6, 0x94]); // RLP prefix for a list of two items
-            bytes2.extend(&proxy_bytes); // The proxy address
-            bytes2.push(0x01); // The nonce of the contract
-            let hash2 = Keccak256::digest(&bytes2);
-        
-            // resulting hash -> The last 20 bytes (40 characters) of the hash.
-            let mut address = [0u8; 20];
-            address.copy_from_slice(&hash2[12..]);
+            /* NOTE: 
+             * This essentially repeats the code in generate_salt. Could be useful for future changes of the function. 
+             * Is there a better way of testing this?
+            */ 
+            let addr: [u8; 20] = calc_addr_with_bytes(deployer, &salt);
 
-            assert!(hex::encode(address).starts_with(run));
+            assert!(hex::encode(addr).starts_with(run));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,8 @@ use errors::Create3GenerateSaltError;
 use rand::{distributions::Alphanumeric, Rng};
 use sha3::{Digest, Keccak256};
 
-// TODO: rename functions in major release to make sense with previously mentioned fn
-// TODO: should panic/return a Result object if prefix/suffix has incorrect characters
 // TODO: add regex fn for salt generation
-// TODO: convert panics into Results
+// TODO: add additional input checks to binary
 
 // Proxy bytecode - Deplyed contract bytecode doesn't effect the deterministic address.
 const KECCAK256_PROXY_CHILD_BYTECODE: [u8; 32] = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod errors;
 
 use std::{
-    ops::Deref,
     sync::{Arc, RwLock},
     thread,
 };
@@ -9,9 +8,6 @@ use std::{
 use errors::Create3GenerateSaltError;
 use rand::{distributions::Alphanumeric, Rng};
 use sha3::{Digest, Keccak256};
-
-// TODO: add regex fn for salt generation
-// TODO: add additional input checks to binary
 
 // Proxy bytecode - Deplyed contract bytecode doesn't effect the deterministic address.
 const KECCAK256_PROXY_CHILD_BYTECODE: [u8; 32] = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
                 println!(
                     "\x1b[32mSalt for prefix {}:\x1b[0m 0x{}",
                     prefix,
-                    hex::encode(&salt)
+                    hex::encode(&salt.1)
                 );
                 break;
             }


### PR DESCRIPTION
In this minor PR, I added some basic tests to the current library functions as was mentioned in the code of the TODOs. I also changed one of the pieces of documentation to correctly reflect the argument. A minor patch could be made to include that small change, but we can wait for a future update if that's too much of a hassle for too little benefit.

While doing this PR, I identified some TODOs that would be helpful in future PRs (some would require either a minor or major version update):  
- Create function that accepts salt as &[u8; 32] instead of just &[u8]
- Rename functions in major release to make sense with previously mentioned fn
- Should panic/return a Result object if prefix/suffix has incorrect characters
- Add regex function for salt generation
- Convert panics into Results
- Rename the salt_suffix argument to salt_prefix